### PR TITLE
implement full-text search using jekyll

### DIFF
--- a/search.json
+++ b/search.json
@@ -12,7 +12,8 @@ search: exclude
 "tags": "{{ page.tags }}",
 "keywords": "{{page.keywords}}",
 "url": "{{ page.url | remove: "/"}}",
-"summary": "{{page.summary | strip }}"
+"summary": "{{page.summary | strip }}",
+"body": "{{ page.content | strip_html | strip_newlines | replace: '\', '\\\\' | replace: '"', '\\"' | replace: '	', '    '}}"
 }
 {% unless forloop.last and site.posts.size < 1 %},{% endunless %}
 {% endunless %}


### PR DESCRIPTION
- uses jekyll to implement full text search (doesnt prioritize search between content vs tittle, doesn't work when trailing non alphanumeric characters are include - i.e searches for direct string only) (not a *smart* search)