### PR TITLE
Change `tidal analyze` to `tidal analyze web`

### DIFF
--- a/pages/tidal tools/analyze.md
+++ b/pages/tidal tools/analyze.md
@@ -9,54 +9,86 @@ folder: tidaltools
 ---
 
 
-## Tidal Analyze
-Now that you have [discovered](discover.html) your FQDNs for your specified Discovery Plan, the next step is to rapidly capture what technologies are in use, on which networks and with what DNS configuration.
+## Tidal Analyze Web
 
-Tidal Analyze will fingerprint the technology on both your internet sites and intranet applications behind your firewall in seconds, without needing to install agents. Whether you have 1 or 1 million end points, Tidal Tools will centralize the data gathered in our platform for you to analyze.
+Now that you have [discovered](discover.html) your FQDNs for your specified
+Discovery Plan, the next step is to rapidly capture what technologies are in
+use, on which networks and with what DNS configuration.
 
-Simplify your application centric discovery with Tidal Analyze.
+Tidal Analyze Web will fingerprint the technology on both your internet sites and
+intranet applications behind your firewall in seconds, without needing to
+install agents. Whether you have one or one million end points, Tidal Tools will
+centralize the data gathered in our platform for you to analyze.
+
+Simplify your application centric discovery with Tidal Analyze Web.
 
 ## Gathering your domains and URLs
 
 Simply save a list of URLs or FQDNs in a text file and use that as input.
 
-Or use the [discovery command](discover.html) to scan your network and DNS to gather a list of relevant domains.
+Or use the [discovery command](discover.html) to scan your network and DNS to
+gather a list of relevant domains.
 
 
 ## Analyzing FQDNs and URLs
-Now that we have our relevant domains and URLs in *my_urls.txt*, we can analyze them with:
 
-`tidal analyze my_urls.txt --upload`
+Now that we have our relevant domains and URLs in *my_urls.txt*, we can analyze
+them with:
 
-{% include tip.html content="You can also utilize the standard output of URLs and FQDNs from [Tidal Discover](discover.html) as input.<br/><br/> `` tidal discover --plan my_plan.yml  | tidal analyze --upload``"  %}
+```
+tidal analyze web my_urls.txt --upload
+```
 
-{% include callout.html content="Are you running this behind a firewall or in a private network? No problem, drop the `--upload` flag, continue on and then checkout the Uploading to your account section below. " type="primary" %}
+{% include tip.html content="
+You can also utilize the standard output of URLs
+and FQDNs from [Tidal Discover](discover.html) as input.
+```
+tidal discover --plan my_plan.yml  | tidal analyze web --upload
+```
+" %}
+
+{% include callout.html content="
+Are you running this behind a firewall or in a private network? No problem,
+drop the `--upload` flag, continue on and then checkout the Uploading to your
+account section below.
+" type="primary" %}
 
 ## Uploading to Tidal Migrations API
 
-After recieving the results of Tidal Analyze, you may or may not be connected to the internet.
+After recieving the results of Tidal Analyze Web, you may or may not be connected
+to the internet.
 
-If you are so, you can import it to your Tidal Migrations account with the following flag:
+If you are so, you can import it to your Tidal Migrations account with the
+following flag:
 
-`tidal analyze my_urls.txt --upload `
+```
+tidal analyze web my_urls.txt --upload
+```
 
-If you aren't connected to the internet, you also have the option to save the results in a JSON file to import at a later time. This can be done with the following steps:
+If you aren't connected to the internet, you also have the option to save the
+results in a JSON file to import at a later time. This can be done with the
+following steps:
 
-1. Run this command to run the analysis and save the results to the file *analyze_output.json*:
+1. Run this command to run the analysis and save the results to the file
+   *analyze_output.json*:
 
+```
+tidal analyze web my_urls.txt --type json > analyze_output.json
+```
 
-    ``tidal analyze my_urls.txt --type json > analyze_output.json ``
-
-2. Copy the file, *analyze_output.json* and install [Tidal Tools](tidal-tools.html), on a computer with internet access.
+2. Copy the file, *analyze_output.json* and install [Tidal
+   Tools](tidal-tools.html), on a computer with internet access.
 3. [Login to Tidal Tools](tidal-tools.html#login) with `tidal login`
-4. Run this command to upload your previously generated data to your Tidal Migrations account:
+4. Run this command to upload your previously generated data to your Tidal
+   Migrations account:
 
-
-    `` tidal analyze --upload-file analyze_output.json ``
+```
+tidal analyze web --upload-file analyze_output.json
+```
 
 ### Accessing your domains in the Tidal API
 
-Once you have imported the results to the Tidal API, your domains will appear on the right hand side navigation bar under
+Once you have imported the results to the Tidal API, your domains will appear
+on the right hand side navigation bar under
 
-
-*Assess* -> *URLs*.
+**Assess** > **URLs**.

--- a/pages/tidal tools/analyze.md
+++ b/pages/tidal tools/analyze.md
@@ -1,7 +1,7 @@
 ---
-title: Tidal Analyze
+title: Tidal Analyze Web
 keywords: analyze, applications, domains, URLs, upload
-last_updated: April 24, 2018
+last_updated: April 23, 2020
 summary: "Analyze your applications and determine their technologies and network data."
 sidebar: main_sidebar
 permalink: analyze.html
@@ -72,9 +72,9 @@ following steps:
 1. Run this command to run the analysis and save the results to the file
    *analyze_output.json*:
 
-```
-tidal analyze web my_urls.txt --type json > analyze_output.json
-```
+   ```
+   tidal analyze web my_urls.txt --type json > analyze_output.json
+   ```
 
 2. Copy the file, *analyze_output.json* and install [Tidal
    Tools](tidal-tools.html), on a computer with internet access.
@@ -82,9 +82,9 @@ tidal analyze web my_urls.txt --type json > analyze_output.json
 4. Run this command to upload your previously generated data to your Tidal
    Migrations account:
 
-```
-tidal analyze web --upload-file analyze_output.json
-```
+   ```
+   tidal analyze web --upload-file analyze_output.json
+   ```
 
 ### Accessing your domains in the Tidal API
 

--- a/pages/tidal tools/aws.md
+++ b/pages/tidal tools/aws.md
@@ -8,28 +8,46 @@ permalink: tidal-tools-aws.html
 folder: tidaltools
 ---
 
-{% include note.html content="This page describes how to configure and use Tidal Tools on AWS. For general installation and configuration instructions please refer to [Getting Started with Tidal Tools](tidal-tools.html) guide." %}
+{% include note.html content="
+This page describes how to configure and use Tidal Tools on AWS. For general
+installation and configuration instructions please refer to [Getting Started
+with Tidal Tools](tidal-tools.html) guide.
+" %}
 
 ## Using Tidal Tools
 
-Tidal Tools is a command-line application. Such applications are also called CLI (command-line interface) applications. To operate it needs to be run from a terminal or command-line prompt. Connect to your Tidal Tools AWS virtual machine (VM) and run the following command (i.e type the text written with monospaced font and press Enter key):
+Tidal Tools is a command-line application. Such applications are also called
+CLI (command-line interface) applications. To operate it needs to be run from a
+terminal or command-line prompt. Connect to your Tidal Tools AWS virtual
+machine (VM) and run the following command (i.e type the text written with
+monospaced font and press Enter key):
 
 ```
 tidal
 ```
 
-The output from the above command should list all the available Tidal Tools subcommands. Running `tidal help <subcommand>` or `tidal <subcommand> --help` (change `<subcommand>` with the actual subcommand from the list) will show more information about that subcommand.
+The output from the above command should list all the available Tidal Tools
+subcommands. Running `tidal help <subcommand>` or `tidal <subcommand> --help`
+(change `<subcommand>` with the actual subcommand from the list) will show more
+information about that subcommand.
 
-Some of the subcommands, for example `tidal analyze`, work independently and immediately provide results. While some other subcommands, for example `tidal analyze code`, require access to the Tidal Migrations API.
+Some of the subcommands, for example `tidal analyze web`, work independently and
+immediately provide results. While some other subcommands, for example `tidal
+analyze code`, require access to the Tidal Migrations API.
 
 To summarize,
 
-* Tidal Tools seamlessly integrates with the [Tidal Migrations API](tidal-tools.html#connecting-to-the-api) and SaaS platform;
-* Tidal Tools can be used independently of the API for some features, while some features do require access to the API to be used;
+* Tidal Tools seamlessly integrates with the [Tidal Migrations
+  API](tidal-tools.html#connecting-to-the-api) and SaaS platform;
+* Tidal Tools can be used independently of the API for some features, while
+  some features do require access to the API to be used;
 * Signing up and using the API is optional when using Tidal Tools.
 
-To see what you can do with `tidal`, checkout some of our other articles about [creating sync jobs](sync-servers.html) or[ analyzing your applications](analyze.html) via their URLs.
+To see what you can do with `tidal`, checkout some of our other articles about
+[creating sync jobs](sync-servers.html) or[ analyzing your
+applications](analyze.html) via their URLs.
 
 ## Troubleshooting
 
-If you are having problems related to Tidal Tools, [the following tips](troubleshooting.html) should help you getting things working.
+If you are having problems related to Tidal Tools, [the following
+tips](troubleshooting.html) should help you getting things working.

--- a/pages/tidal tools/aws.md
+++ b/pages/tidal tools/aws.md
@@ -1,7 +1,7 @@
 ---
 title: Getting Started with Tidal Tools on AWS
 keywords: aws, marketplace, tidal tools
-last_updated: February 11, 2020
+last_updated: April 23, 2020
 summary: Configure and use Tidal Tools on AWS
 sidebar: main_sidebar
 permalink: tidal-tools-aws.html

--- a/pages/tidal tools/getstarted.md
+++ b/pages/tidal tools/getstarted.md
@@ -1,7 +1,7 @@
 ---
 title: Getting Started with Tidal Tools
 keywords: install, login, connect, configuration, proxy, environment
-last_updated: Feb 13, 2018
+last_updated: April 23, 2020
 summary: "Get started working with Tidal Tools"
 sidebar: main_sidebar
 permalink: tidal-tools.html

--- a/pages/tidal tools/getstarted.md
+++ b/pages/tidal tools/getstarted.md
@@ -8,47 +8,75 @@ permalink: tidal-tools.html
 folder: tidaltools
 ---
 
-{% include note.html content="This page describes general installation and configuration instructions for Tidal Tools. If you are looking for specific AWS usage instractions please refer to [Getting Started with Tidal Tools on AWS](tidal-tools-aws.html) guide." %}
+{% include note.html content="
+This page describes general installation and configuration instructions for
+Tidal Tools. If you are looking for specific AWS usage instractions please
+refer to [Getting Started with Tidal Tools on AWS](tidal-tools-aws.html) guide.
+" %}
 
-Here we outline how to get started working with Tidal Tools via the command line.
+Here we outline how to get started working with Tidal Tools via the command
+line.
 
 ## Downloading & Installing {#install}
 
-Tidal Tools is a cross platform CLI utility that you can use to discover and analyze your applications.
-[Easily install Tidal Tools](https://get.tidal.sh) on your operating system.
+Tidal Tools is a cross platform CLI utility that you can use to discover and
+analyze your applications. [Easily install Tidal Tools](https://get.tidal.sh)
+on your operating system.
 
 ### Dependencies
 
-If you plan to use the `tidal analyze` command to analyze your source code (or soon your databases!) You will need to install Docker Community Edition. To install Docker on your system you can check [Docker's documentation directly](https://docs.docker.com/install/). Once installed you can [verify it is installed and working correctly](/troubleshooting.html) with the command `tidal doctor`.
+If you plan to use the `tidal analyze code` command to analyze your source code
+or `tidal analyze db` to analyze your databases, you will need to install
+Docker Community Edition. To install Docker on your system you can check
+[Docker's documentation directly](https://docs.docker.com/install/). Once
+installed you can [verify it is installed and working
+correctly](/troubleshooting.html) with the command `tidal doctor`.
 
-Docker for Windows supports both Linux containers and Windows containers, however **Tidal Tools works when your Docker installation is set to to use Linux containers**. [Set up Docker for Windows to use Linux containers](/troubleshooting.html#docker-linux-containers).
+Docker for Windows supports both Linux containers and Windows containers,
+however **Tidal Tools works when your Docker installation is set to to use
+Linux containers**. [Set up Docker for Windows to use Linux
+containers](/troubleshooting.html#docker-linux-containers).
 
 ## Using Tidal Tools
+
 To get started, from a new terminal or Powershell prompt, simply run:
 
 ```
 tidal
 ```
 
-To see what you can do with the tidal checkout some of our other articles about creating sync jobs or analyzing your applications via their URLs.
+To see what you can do with the tidal checkout some of our other articles about
+creating sync jobs or analyzing your applications via their URLs.
 
 ## Connecting to the API
-Once you have Tidal Tools installed you need to configure access to the API. [Register for a free account](https://get.tidalmg.com/) with Tidal Migrations to get the connection details.
 
-There are several ways to authenticate with the Tidal Migrations API, we recommend the first one, `tidal login`, because your password is never persisted to disk.
+Once you have Tidal Tools installed you need to configure access to the API.
+[Register for a free account](https://get.tidalmg.com/) with Tidal Migrations
+to get the connection details.
+
+There are several ways to authenticate with the Tidal Migrations API, we
+recommend the first one, `tidal login`, because your password is never
+persisted to disk.
 
 ### Tidal Login command {#login}
-To authenticate with the API type `tidal login` and follow the prompts. This should provide and store an access token for you that gives you access for 8 hours. Once it is expired, the user must login again and obtain another token.
 
-**We recommend that you utilise this command because it doesn't store your password.** If you must store the password, you can authenticate using the methods below.
+To authenticate with the API type `tidal login` and follow the prompts. This
+should provide and store an access token for you that gives you access for 8
+hours. Once it is expired, the user must login again and obtain another token.
+
+**We recommend that you utilise this command because it doesn't store your
+password.** If you must store the password, you can authenticate using the
+methods below.
 
 ### Alternative authentication methods
 
 #### Configuration file
 
-Alternatively, you can use the `tidal config` command to manually set your credentials.
+Alternatively, you can use the `tidal config` command to manually set your
+credentials.
 
-For example, you can set your username, password and URL with the three following commands:
+For example, you can set your username, password and URL with the three
+following commands:
 
 ```
 tidal config set tidal.email [set your email]
@@ -65,21 +93,26 @@ tidal:
   url: https://my_instance_name_here.tidalmg.com
 ```
 
-On macOS the config file is located: `$HOME/Library/Preferences/tidal/config.yaml`
+On macOS the config file is located:
+`$HOME/Library/Preferences/tidal/config.yaml`
 
 On Linux systems it is: `$HOME/.config/tidal/config.yaml`
 
 And on Windows it is: `%AppData%\tidal\config.yaml`
 
 #### Environment Variables
-You can specify your credentials as environment variables. If so, these variables need to be set:
+
+You can specify your credentials as environment variables. If so, these
+variables need to be set:
 
 - `TIDAL_EMAIL`
 - `TIDAL_PASSWORD`
 - `TIDAL_URL`
 
 #### Dynamically
-Alternatively you can pass in your credentials on each request as command line arguments using the following flags:
+
+Alternatively you can pass in your credentials on each request as command line
+arguments using the following flags:
 
 ```
 --tidal-email youremail@address.here
@@ -88,14 +121,17 @@ Alternatively you can pass in your credentials on each request as command line a
 ```
 
 ## Testing connectivity and authentication
-Once you have set your credentials you can test your connectivity and authentication to the API with the ping command:
+
+Once you have set your credentials you can test your connectivity and
+authentication to the API with the ping command:
 
 ```
 tidal ping
 ```
 
 ### Using a Proxy
-If you need to use a proxy, you can specify it with the https_proxy variable.
+
+If you need to use a proxy, you can specify it with the `https_proxy` variable.
 
 On macOS and Linux you would run:
 
@@ -109,6 +145,9 @@ and on Windows:
 set https_proxy=1.1.1.1:123
 ```
 
-Of course replacing `1.1.1.1` with your proxy IP address and `123` with the port number.
+Of course replacing `1.1.1.1` with your proxy IP address and `123` with the
+port number.
 
-Once you have this set, you should be able to run `tidal ping` successfully. Remember that you will need to set this for every new terminal session you start.
+Once you have this set, you should be able to run `tidal ping` successfully.
+Remember that you will need to set this for every new terminal session you
+start.

--- a/pages/user guides/discovery_techniques.md
+++ b/pages/user guides/discovery_techniques.md
@@ -9,119 +9,163 @@ folder: userguides
 permalink: index.html
 ---
 
-Cloud migration is the process of moving your data, applications, and other elements to the cloud. However, the path to the cloud can be long and painful without proper planning and execution.
-By following Tidal Migration's six discovery layering techniques, you will be migrating to the cloud with ease!
+Cloud migration is the process of moving your data, applications, and other
+elements to the cloud. However, the path to the cloud can be long and painful
+without proper planning and execution.  By following Tidal Migration's six
+discovery layering techniques, you will be migrating to the cloud with ease!
 
-{% include image.html file="layered_discovery.png" caption="Tidal Migrations' layered approach to application discovery, for cloud migration." %}
+{% include image.html file="layered_discovery.png" caption="Tidal Migrations'
+layered approach to application discovery, for cloud migration." %}
 
 # Six Steps To Discovery Bliss
 
 ## 1) Import Your Spreadsheets
 
-If your already have some data collected in spreadsheets, the first step to begin your cloud migration project is importing a spreadsheet of Virtualization Clusters, Servers, Databases Instances and Applications. Tidal Migration's importer will guide you through mapping your columns to our fields, create your own fields and even make associations between dependencies if you have captured these.
+If your already have some data collected in spreadsheets, the first step to
+begin your cloud migration project is importing a spreadsheet of Virtualization
+Clusters, Servers, Databases Instances and Applications. Tidal Migration's
+importer will guide you through mapping your columns to our fields, create your
+own fields and even make associations between dependencies if you have captured
+these.
 
-_NB: See additional ways on importing your [applications](importapps.html) and [servers](import_servers.html) in the API docs._
+_NB: See additional ways on importing your [applications](importapps.html) and
+[servers](import_servers.html) in the API docs._
 
-<hr />
+---
 
 ## 2) Integrate Your Hypervisors
 
-Once you have imported your data, you can begin to synchronize your inventories via [`tidal sync servers`](sync-servers.html).
-Tidal sync supports many server inventory management tools such as VMWare and HyperV with more possible via scripting ([ask us](https://tidalmigrations.com/contact)).
+Once you have imported your data, you can begin to synchronize your inventories
+via [`tidal sync servers`](sync-servers.html).  Tidal sync supports many server
+inventory management tools such as VMWare and HyperV with more possible via
+scripting ([ask us](https://tidalmigrations.com/contact)).
 
-If you have VM Ware's vSphere, [`tidal sync vsphere`](#vsphere-sync) will handle everying with just read-only credentials required.
+If you have VM Ware's vSphere, [`tidal sync vsphere`](#vsphere-sync) will
+handle everying with just read-only credentials required.
 
 
 ### Scheduling your sync:
-It is useful to setup a cron job or Windows Scheduled Task for this process, and we recommend synchronizing your inventories no more than once per day.
 
-This will keep your resource inventory up to date and show you usage trends over time in the _Analyze_ feature.
+It is useful to setup a cron job or Windows Scheduled Task for this process,
+and we recommend synchronizing your inventories no more than once per day.
 
-<hr />
+This will keep your resource inventory up to date and show you usage trends
+over time in the _Analyze_ feature.
+
+---
 
 ## 3) Aggregate Server Usage Statistics
 
-Tidal Migrations provides you with a simple and effective way to [gather machine statistics](https://github.com/tidalmigrations/machine_stats) (RAM, Storage, CPU allocations and usage) from Windows and UNIX/Linux server environmens.
-In Windows, we use WinRM to Invoke-Command across your servers, and for *NIX we leverage ansible. Both of these approaches output JSON which is securely sent to your Tidal Migrations instance using the tidal command.
+Tidal Migrations provides you with a simple and effective way to [gather
+machine statistics](https://github.com/tidalmigrations/machine_stats) (RAM,
+Storage, CPU allocations and usage) from Windows and UNIX/Linux server
+environmens.
+In Windows, we use WinRM to Invoke-Command across your servers, and for *NIX we
+leverage ansible. Both of these approaches output JSON which is securely sent
+to your Tidal Migrations instance using the tidal command.
 
-Checkout this [guide](sync_hyper-v.html) for a quick and clean approach to gathering server usage statistics. See the [machine_stats](https://github.com/tidalmigrations/machine_stats) repository for more implementation details.
+Checkout this [guide](sync_hyper-v.html) for a quick and clean approach to
+gathering server usage statistics. See the
+[machine_stats](https://github.com/tidalmigrations/machine_stats) repository
+for more implementation details.
 
-_NB: Feel free to fork the repo and modify to suit your needs, or to show your security team and give them comfort.  This extensibility and transparency is core to our approach._
+_NB: Feel free to fork the repo and modify to suit your needs, or to show your
+security team and give them comfort.  This extensibility and transparency is
+core to our approach._
 
-<hr />
+---
 
 ## 4) Fingerprint Web Applications
 
 **a.)** The initial step in your cloud journey is discovering what you have.
-It can be hard to remain informed about all the domains and applications
-hosted in your environment, which is why we created the `tidal discover` command.
-With your customized _Discovery Plan_ you can obtain both private and public domains
-within your datacentres in under 60 seconds.
+It can be hard to remain informed about all the domains and applications hosted
+in your environment, which is why we created the `tidal discover` command.
+With your customized _Discovery Plan_ you can obtain both private and public
+domains within your datacentres in under 60 seconds.
 
-[This tidal-tools guide](discover.html) contains examples for creating your own _Discovery Plan_ to scan multiple networks and DNS services.
+[This tidal-tools guide](discover.html) contains examples for creating your own
+_Discovery Plan_ to scan multiple networks and DNS services.
 
-**b.)** With a list of domains in hand, the next step is to _analyze_ the applications hosted on these domains.
+**b.)** With a list of domains in hand, the next step is to _analyze_ the
+applications hosted on these domains.
 
-`tidal analyze` will fingerprint the technology on both your internet sites and intranet applications behind your firewall in seconds, _without needing to install agents._
-Whether you have 1 or 1 million end points, Tidal Tools centralizes the data gathered into our platform for you to analyze further and plan with, simplifying your application centric cloud migration.
+`tidal analyze web` will fingerprint the technology on both your internet sites
+and intranet applications behind your firewall in seconds, _without needing to
+install agents._
+Whether you have 1 or 1 million end points, Tidal Tools centralizes the data
+gathered into our platform for you to analyze further and plan with,
+simplifying your application centric cloud migration.
 
-For detailed information and steps on analyzing your domains, be sure to checkout this [guide](analyze.html).
+For detailed information and steps on analyzing your domains, be sure to
+checkout this [guide](analyze.html).
 
-<hr />
+---
 
 ## 5) Analyze Your Databases
-Analyze all of your databases in minutes and _measure_ the migration difficulty.
 
-After running `tidal analyze db your_config.yml` against your databases ([see guide](/analyze_database.html)), you will understand which database features in your Oracle or SQL Server installations make it difficult to adopt cloud-native database offerings and also identify which applications are connecting to your databases.
+Analyze all of your databases in minutes and _measure_ the migration
+difficulty.
 
-With over 100 unique characteristics considered, comparisons are made with the data platforms available in the cloud(s) you are migrating to which provide you with _data-driven insights_ for planning your cloud migration.
+After running `tidal analyze db your_config.yml` against your databases ([see
+guide](/analyze_database.html)), you will understand which database features in
+your Oracle or SQL Server installations make it difficult to adopt cloud-native
+database offerings and also identify which applications are connecting to your
+databases.
 
-Follow the steps in [the guide](/analyze_database.html), and you will be
-able to quantify the difficulty in migrating your database from Oracle
-to PostreSQL; or from SQL Server to AWS Aurora etc.
+With over 100 unique characteristics considered, comparisons are made with the
+data platforms available in the cloud(s) you are migrating to which provide you
+with _data-driven insights_ for planning your cloud migration.
 
-<hr />
+Follow the steps in [the guide](/analyze_database.html), and you will be able
+to quantify the difficulty in migrating your database from Oracle to PostreSQL;
+or from SQL Server to AWS Aurora etc.
+
+---
 
 
 ## 6) Analyze Your Source Code
 
 Finally, to find the applications which will migrate more easily to
-cloud-native technologies you can analyze your source code and rank
-your applications by _Cloud Readiness_.
+cloud-native technologies you can analyze your source code and rank your
+applications by _Cloud Readiness_.
 
-Doing this for each of your custom applications which have a _Transition
-Type_ of Refactor or Replatform will give you the data needed to prioritize your
-application migrations.  To analyze your source code, you need the
-`Application ID`, to be logged in with tidal-tools and a copy of the
-source code checked out.
+Doing this for each of your custom applications which have a _Transition Type_
+of Refactor or Replatform will give you the data needed to prioritize your
+application migrations.  To analyze your source code, you need the `Application
+ID`, to be logged in with tidal-tools and a copy of the source code checked
+out.
 
 You can find the `Application ID` in the URL bar when looking at an
-application.  e.g. if I'm loking at an application in Tidal Migrations,
-the URL will show `https://demo2.tidalmg.com/#/apps/111`  Here, `111` is
-my `Application ID`.
+application.  e.g. if I'm loking at an application in Tidal Migrations, the URL
+will show `https://demo2.tidalmg.com/#/apps/111`  Here, `111` is my
+`Application ID`.
 
 I can now analyze the source code with:
 
 ```
 cd /path/to/source-code
-tidal analyze --app-id 111 .
+tidal analyze code --app-id 111 .
 ```
-To find additional information about this feature, visit the [guide](analyze-source-code.html) on analyzing your source code.
+To find additional information about this feature, visit the
+[guide](analyze-source-code.html) on analyzing your source code.
 
-<hr />
+---
 
 # Conclusion
-Immediately getting an idea of the size and scope of your migration is
-critical to successful cloud migration planning.
 
-Our goal at Tidal Migrations is to provide you with useful information
-within 60 seconds of signup, and letting you layer in additional
-information from discovery sources as needed.
+Immediately getting an idea of the size and scope of your migration is critical
+to successful cloud migration planning.
 
-_You do not need to spend weeks and months installing discovery systems
-to start planning your cloud migration any more._
+Our goal at Tidal Migrations is to provide you with useful information within
+60 seconds of signup, and letting you layer in additional information from
+discovery sources as needed.
+
+_You do not need to spend weeks and months installing discovery systems to
+start planning your cloud migration any more._
 
 
 ---
-Not yet a customer?  See [tidalmigrations.com](https://tidalmigrations.com) and [Try For Free](https://get.tidalmg.com).
+
+Not yet a customer?  See [tidalmigrations.com](https://tidalmigrations.com) and
+[Try For Free](https://get.tidalmg.com).
 

--- a/pages/user guides/discovery_techniques.md
+++ b/pages/user guides/discovery_techniques.md
@@ -2,7 +2,7 @@
 toc: false
 title: Layering Discovery Techniques
 keywords: sync, import, discover, analyze, source code, discovery plan
-last_updated: July, 2018
+last_updated: April 23, 2020
 summary: "A quick guide on the various discovery techniques and how to layer them together to quickly and accurately discover your environment"
 sidebar: main_sidebar
 folder: userguides


### PR DESCRIPTION
This PR introduces some changes related to the recent rename of `tidal analyze` command to `tidal analyze web`.

Also some outdated information was corrected.