### PR TITLE
Remove incorrect key from example app body data

### DIFF
--- a/pages/tidal tools/syncservers.md
+++ b/pages/tidal tools/syncservers.md
@@ -166,7 +166,6 @@ The syncronization of your Applications can be performed by following the above 
       "servers": [{
         "host_name": "trpewrcapbiz02"
       }],
-      "host_name": "trpewrcapbiz02",
       "urls": "https://approvalmanagementsystem.com",
       "transition_overview": "this is the transition_overview of the application",
       "transition_type": 3,


### PR DESCRIPTION
There is no parameter `host_name` for applications. No need to include this in the example.