### PR TITLE
Add GCP guide to navigation menu

### DIFF
--- a/_data/sidebars/main_sidebar.yml
+++ b/_data/sidebars/main_sidebar.yml
@@ -14,6 +14,9 @@ entries:
     - title: Setup Tidal Tools on AWS
       output: web
       url: tidal-tools-aws.html
+    - title: Setup Tidal Tools on GCP
+      output: web
+      url: tidal-tools-gcp.html
     - title: Tidal Tools Autocompletion
       output: web
       url: autocompletion.html


### PR DESCRIPTION
This is ready for a review. Really small change.

It should be merged when the Tidal Tools listing is available to everyone on the GCP marketplace.