### PR TITLE
Improve vSphere integration guide

### DIFF
--- a/pages/tidal tools/vsphere.md
+++ b/pages/tidal tools/vsphere.md
@@ -6,88 +6,38 @@ sidebar: main_sidebar
 permalink: vsphere.html
 folder: tidaltools
 ---
-
-
-
 ## Getting Started
-To get started you will need to have Tidal Tools installed. You can download a copy from https://get.tidal.sh and check out this [article](tidal-tools.html) on how to install.
-
-
+To get started you will need make sure you have a copy of [Tidal Tools](https://get.tidal.sh) and it is [installed](tidal-tools.html).
 
 ## Supported Versions
 ### vSphere 5.5
 NB: When you set the vsphere.server you will likely need to include the default port, 443, in the url. Ex. 192.168.1:443
-
 ### vSphere 6.0
 
 ## vSphere Login
+If you have not logged on to the Tidal API yet, run `tidal login` to do so.
 
-If you have not logged on to the Tidal API yet, the [`tidal login` command](#login) will prompt you to login to the *Tidal API*  with your credentials, and
-then it will also prompt you to login to *vSphere*.
+Once you are logged on to the Tidal API, execute the `tidal login vsphere` command
 
-However, if you are already logged on to the Tidal API, you can skip to execute the `tidal login vsphere` command, which will _only_ prompt you to
-login to vSphere.
+A set of prompts will appear to help you connect to your vSphere account:
 
-If you do wish to login to your vSphere account, you can select the option `y`:
+1. vSphere Server - Either an IP address or a FQDN that resolves to the correct IP for the ESXi or vCenter instance
+2. vSphere Username - A username that has read access to the vCenter or ESXi instance.
+3. vSphere Password - Corresponding password for the user.
+4. vSphere API Endpoint - The default is `/sdk`, unless you know it is not this default, it can left as is.
+5. Use SSL/TLS? - The default is to use SSL (y), which can be left unless you know you can't use it.
+6. Skip HTTPS certificate checks? - The deafult is to not skip (n), which can be left unless you know they need to be skipped.
 
-After which, a set of prompts will appear to help you connect to your vSphere account:
-
-1. vSphere Server
-2. vSphere Username
-3. vSphere Password
-4. vSphere API Endpoint
-5. Use SSL/TLS?
-6. Skip HTTPS certificate checks?
-
-After answering the above prompts, you will see the message _"Login to vSphere successful. Saving config file...Done!"_
-
-
-## Configure
-Once you have Tidal Tools installed you need to configure access to vSphere and Tidal Migrations.
-
-The credentials can be defined using (1) the tidal config command, (2) with a config file or (3) via environment variables. If a config file is present it will be used, if it is not present environment variables will be used. If none of these are defined, you will be prompted to enter the required details.
-
-
-
-### 1) Set interactively
-
-You can set your vSphere credentials with the following commands:
-
-``` tidal config set vsphere.username [your username] ```
-
-``` tidal config set vsphere.password [your password] ```
-
-``` tidal config set vsphere.server 192.168.1.12 ```
-
-
-
-### 2) Config file
+After answering the above prompts, you will see the message
 
 ```
-vsphere:
-  username: my_user_name_here
-  password: my_secure_vsphere_password
-  server: 1.1.1.1
-tidal:
-  email: my_user_name_here
-  password: my_secure_password_here
-  url: https://my_instance_name_here.tidalmg.com
+Login to vSphere successful. Saving config file...Done!
 ```
-
-### 3) Environment Variables
-
-If you would like to set these credentials and settings via environment variables, you can use these variables:
-
-- VSPHERE_USERNAME
-- VSPHERE_PASSWORD
-- VSPHERE_SERVER
-- VSPHERE_TLS
-- VSPHERE_INSECURE
 
 ## Sync {#vsphere-sync}
 Syncronizing your vSphere inventory with Tidal Migrations is simple with:
 
-`` tidal sync vsphere ``
+`tidal sync vsphere`
 
 ```
 Loading data..
@@ -99,7 +49,10 @@ Logged in.
 Updating via API..
 Update successful
 ```
-You can easily split this into two commands to allow you to inject other metadata about your inventory, if needed. To do this simply use the get command to get your inventory. Modify it as you need and then you can use the sync command to upload your data.
+
+You can easily split this into two commands to allow you to inject other metadata about your inventory, if needed.
+To do this simply use the get command to get your inventory.
+Modify it as you need and then you can use the sync command to upload your data.
 
 1. `tidal get vsphere`, will fetch your vSphere inventory and output JSON (check it out!).
 
@@ -107,9 +60,51 @@ You can easily split this into two commands to allow you to inject other metadat
 
 3. `tidal sync servers`, will take that JSON from STDIN and send it to Tidal Migrations.
 
-`` tidal get vsphere | ./modify_script.rb | tidal sync servers ``
+```
+tidal get vsphere | ./modify_script.rb | tidal sync servers
+```
 
 ## Repeat
+You can easily set this to run periodically. The integration updates records if they already exist, or creates new records if they don't.
+Look at [setting this command up as a cron job](https://www.digitalocean.com/community/tutorials/how-to-use-cron-to-automate-tasks-on-a-vps) that once per day.
 
-You can easily set this to run periodically. The integration updates records if they already exist, or creates new records if they don't. Look at setting this command up as a cron job, [here is a great resource on how to do that](https://www.digitalocean.com/community/tutorials/how-to-use-cron-to-automate-tasks-on-a-vps).
+## Additional Configuration Options
+The integration can be configured with several other methods besides `tidal login`.
+You can use these alternate approaches if they better suite your use case.
 
+The other options are to use, the `tidal config` command, a config file via `--config` or via environment variables.
+If a config file is present it will be used, if it is not present environment variables will be used.
+If neither are present, you will be prompted to enter the required details.
+
+### 1) Set interactively
+You can set your vSphere credentials with the following commands:
+
+`tidal config set vsphere.username [your username]`
+
+`tidal config set vsphere.password [your password]`
+
+`tidal config set vsphere.server 192.168.1.12`
+
+### 2) Config file
+A file that has similar content to below, called `config.yml`:
+
+```
+vsphere:
+  username: my_user_name_here
+  password: my_secure_vsphere_password
+  server: 1.1.1.1
+tidal:
+  email: my_user_name_here
+  password: my_secure_password_here
+  url: https://my_instance_name_here.tidalmg.com
+```
+Could be used with a command: `tidal sync vsphere --config config.yml`
+
+### 3) Environment Variables
+To configure with environment variables, you can use these variables to set the values and Tidal Tools will use them.
+
+- VSPHERE_USERNAME
+- VSPHERE_PASSWORD
+- VSPHERE_SERVER
+- VSPHERE_TLS
+- VSPHERE_INSECURE

--- a/pages/tidal tools/vsphere.md
+++ b/pages/tidal tools/vsphere.md
@@ -1,13 +1,13 @@
 ---
 title: Integrate Tidal Migrations with vSphere
 keywords: vsphere, login, configure, sync, environment
-last_updated: Feb 13, 2018
+last_updated: Dec 2, 2020
 sidebar: main_sidebar
 permalink: vsphere.html
 folder: tidaltools
 ---
 ## Getting Started
-To get started you will need make sure you have a copy of [Tidal Tools](https://get.tidal.sh) and it is [installed](tidal-tools.html).
+To get started you will need to make sure you have a copy of [Tidal Tools](https://get.tidal.sh) and it is [installed](tidal-tools.html).
 
 ## Supported Versions
 ### vSphere 5.5
@@ -24,11 +24,11 @@ A set of prompts will appear to help you connect to your vSphere account:
 1. vSphere Server - Either an IP address or a FQDN that resolves to the correct IP for the ESXi or vCenter instance
 2. vSphere Username - A username that has read access to the vCenter or ESXi instance.
 3. vSphere Password - Corresponding password for the user.
-4. vSphere API Endpoint - The default is `/sdk`, unless you know it is not this default, it can left as is.
+4. vSphere API Endpoint - The default is `/sdk`, It can be left as is, unless you know your setup does not use the default.
 5. Use SSL/TLS? - The default is to use SSL (y), which can be left unless you know you can't use it.
-6. Skip HTTPS certificate checks? - The deafult is to not skip (n), which can be left unless you know they need to be skipped.
+6. Skip HTTPS certificate checks? - The default is to not skip (n), which can be left unless you know they need to be skipped.
 
-After answering the above prompts, you will see the message
+After answering the above prompts, you will see the message:
 
 ```
 Login to vSphere successful. Saving config file...Done!
@@ -66,17 +66,23 @@ tidal get vsphere | ./modify_script.rb | tidal sync servers
 
 ## Repeat
 You can easily set this to run periodically. The integration updates records if they already exist, or creates new records if they don't.
-Look at [setting this command up as a cron job](https://www.digitalocean.com/community/tutorials/how-to-use-cron-to-automate-tasks-on-a-vps) that once per day.
+Look at [setting this command up as a cron job](https://www.digitalocean.com/community/tutorials/how-to-use-cron-to-automate-tasks-on-a-vps) that runs once per day.
 
 ## Additional Configuration Options
 The integration can be configured with several other methods besides `tidal login`.
 You can use these alternate approaches if they better suite your use case.
 
-The other options are to use, the `tidal config` command, a config file via `--config` or via environment variables.
-If a config file is present it will be used, if it is not present environment variables will be used.
-If neither are present, you will be prompted to enter the required details.
+The other configuration options available are to set values in the configuration file (either interactively or manually) or set environment variables.
 
-### 1) Set interactively
+The credentials and configuration settings take precedence in the following order:
+
+1. [Environment Variables](#2-environment-variables)
+2. [Configuration file](#1-configuration-file)
+3. [Prompt in the terminal](#vsphere-login) - If neither are present, you will be prompted to enter the required details and they are stored in the [default configuration file](/tidal-tools.html#configuration-file).
+
+### 1) Configuration File
+
+#### Set Interactively
 You can set your vSphere credentials with the following commands:
 
 `tidal config set vsphere.username [your username]`
@@ -85,8 +91,10 @@ You can set your vSphere credentials with the following commands:
 
 `tidal config set vsphere.server 192.168.1.12`
 
-### 2) Config file
-A file that has similar content to below, called `config.yml`:
+The set values are stored in the [default configuration file](/tidal-tools.html#configuration-file).
+
+#### Set Manually
+You can create a file, for example `config.yml`, with content similar to this:
 
 ```
 vsphere:
@@ -98,10 +106,11 @@ tidal:
   password: my_secure_password_here
   url: https://my_instance_name_here.tidalmg.com
 ```
-Could be used with a command: `tidal sync vsphere --config config.yml`
+That can be used with a command: `tidal sync vsphere --config config.yml`
 
-### 3) Environment Variables
-To configure with environment variables, you can use these variables to set the values and Tidal Tools will use them.
+### 2) Environment Variables
+
+Another alternative is to set the following environment variables with the needed values and Tidal Tools will use them:
 
 - VSPHERE_USERNAME
 - VSPHERE_PASSWORD


### PR DESCRIPTION
Improves the content in the vSphere integration guide.

- Corrects some content and steps that were out of date.
- Adds more information for the needed inputs and values.
- Improves the wording on the existing content to make it easier to read and follow.
- Reorders some content, moving the 'other' configuration options to the end. They are optionl, not really need used by most people.
- Also improves the markdown spacing and formatting, no visible impact on render though.
