### PR TITLE
Remove editor config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-// Place your settings in this file to overwrite default and user settings.
-{
-  "files.associations": {
-    "*.html": "liquid"
-  }
-}


### PR DESCRIPTION
Removes dotfile editor config from the repo. Not needed and if it is, can be setup by people who need it and be set to ignore in .gitignore.
