### PR TITLE
Updates for the database analysis guide

### DIFF
--- a/pages/tidal tools/analyze_database.md
+++ b/pages/tidal tools/analyze_database.md
@@ -98,6 +98,9 @@ databases:
 
 {% include note.html content="It is best to use quotations, either double or single, around the values in the configuration file. To avoid special characters, : { } [ ] , & * # ? | - < > = ! % @ \ \n from being interpreted. Single quotes are safest, if the value has a single quote within it, you can include it by using a two single quotations, ie. `'my''string'` - will become `my'string`." %}
 
+{% include tip.html content="Are you analyzing an Oracle Stanard Edition (SE)
+database? Check out the [advanced configuration below](#advanced-configuration)." %}
+
 - You’re all set! You can now analyze the database with:
 
 ```
@@ -136,3 +139,25 @@ You need to install Docker in order to complete the database analysis. This is b
 
 ##  What about security?
 The entire analysis takes place locally on your machine. The only data that is captured and sent from the analysis are the results of the analysis and metadata. No application data, source code, files or the contents of any files on your machine are ever copied or sent anywhere.
+
+## Advanced Configuration
+
+To use Oracle features included only in the Oracle Standard Edition (SE) license, you
+can set the `analyze_workload` property to `false` in your configuration file. For example:
+
+```
+databases:
+  - id: 111
+    analyze_workload: false
+    engine: Oracle
+    host: 'my-db-host.com'
+    port: 1521
+    db_name: 'orcl'
+    user: 'tidal'
+    password: 'yoursecurepassword1234!'
+    name: 'My-Test-DB'
+```
+
+{% include note.html content="By setting this to `false`, some results from the
+analysis will not be available, including server metrics, connected applications,
+and the workload analysis ranking." %}

--- a/pages/tidal tools/analyze_database.md
+++ b/pages/tidal tools/analyze_database.md
@@ -21,11 +21,14 @@ Tidal Tools is able to analyze Oracle and SQL Server databases with the followin
 
 | Oracle                | SQL Server |
 |-----------------------|
-| Oracle Database 10g Release 2	(10.2) | SQL Server 2008R2 |
-| Oracle Database 11g Release 1	(11.1) | SQL Server 2016   |
-| Oracle Database 11g Release 2	(11.2) | SQL Server 2017   |
-| Oracle Database 12c Release 1	(12.1) |
-| Oracle Database 12c Release 2	(12.2) |
+| [Beta](mailto:info@tidalmigrations.com?subject=Interested in Oracle 8i Database Analysis) Oracle Database 8i (8.1) | SQL Server 2008R2 |
+| Oracle Database 9i Release 2 (9.2)   | SQL Server 2016 |
+| Oracle Database 10g Release 2 (10.2) | SQL Server 2017 |
+| Oracle Database 11g Release 1 (11.1) |
+| Oracle Database 11g Release 2 (11.2) |
+| Oracle Database 12c Release 1 (12.1) |
+| Oracle Database 12c Release 2 (12.2) |
+| Oracle Database 18c (18.1) |
 
 If you have a use case for a different version, definitely let us know at [info@tidalmigrations.com](mailto:info@tidalmigrations.com), we are always adding new capabilities.
 


### PR DESCRIPTION
A few improvements for the database analysis guide:

- Add new supported db version, Oracle 18c
- Add information about `analyze_workload` option

Doesn't impact rendered content:
- Remove redundant whitespace
