### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/" 
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Configures dependabot to open suggested PRs to keep dependencies up to date.

More info - https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates