### PR TITLE
PostgreSQL user permissions script and troubleshooting

### DIFF
--- a/pages/tidal tools/analyze_database.md
+++ b/pages/tidal tools/analyze_database.md
@@ -136,6 +136,15 @@ GRANT SELECT ON pg_catalog.pg_proc TO tidal;
 GRANT SELECT ON pg_catalog.pg_namespace TO tidal;
 ```
 
+For PostgreSQL versions **10 and above** the following `GRANT`s should be also applied:
+
+```sql
+GRANT SELECT ON pg_catalog.pg_hba_file_rules TO tidal;
+GRANT SELECT ON pg_catalog.pg_roles TO tidal;
+GRANT pg_read_all_settings TO tidal;
+GRANT pg_read_all_stats TO tidal;
+```
+
 After creating the user you will need to add the appropriate entry to the [`pg_hba.conf`](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html). For example:
 
 ```

--- a/pages/tidal tools/troubleshooting.md
+++ b/pages/tidal tools/troubleshooting.md
@@ -253,3 +253,11 @@ $ sudo dnf install -y grubby && \
 ```
 
 This command reverts the systemd configuration to use cgroup v1.
+
+### PostgreSQL database fails to analyze with `tidal analyze db` {#postgres}
+
+Check the [PostgreSQL Server
+User](https://guides.tidalmg.com/analyze-database.html#postgresql-server-user)
+script to verify that the all the necessary permissions were granted. Pay
+attention that different permissions should be applied to different PostgreSQL
+versions.


### PR DESCRIPTION
This PR adds the user permissions script section for PostgreSQL 10+ (based on the [upstream script](https://storage.googleapis.com/general-migvisor-public/postgresql_readonly_user.sql)) and the PostgreSQL troubleshooting section to be referred from `tidal analyze db`