### PR TITLE
Add note about large ranges

### DIFF
--- a/pages/user guides/public_urls.md
+++ b/pages/user guides/public_urls.md
@@ -61,3 +61,5 @@ In this case that is `104.194.16.0/22` and `205.210.17.0/24`.
 You should now see a list of domains that belong to your organization.
 With this list you can now continue your discovery by assigning them to applications within Tidal,
 either applications you already have identified or by creating new applications with these URLs as the initial data points.
+
+Note: If the CIDR range you have found is very large (/16 larger) you can use a <a href="https://tidalmigrations.com/subnet-builder/">subnet viewer</a> to break it into smaller ranges.


### PR DESCRIPTION
Adds a note about breaking large CIDR ranges into smaller ones and references the subnet builder on tidalmigrations.com.
