### PR TITLE
Switch references to get.tidalmg.com

### DIFF
--- a/pages/api/authentication.md
+++ b/pages/api/authentication.md
@@ -23,7 +23,7 @@ A request to authenticate into the Tidal Migrations API looks like this:
 
 You will need:
 
-1. Your subdomain -> Refer to [Get Subdomain](https://get.tidalmg.com/workspaces) & type in your email in the prompt bar. Afterwards, You will receive an email with all of your workspaces.
+1. Your subdomain -> Refer to [Get Subdomain](https://get.tidalmg.com/workspaces) & type in your email in the prompt bar. Afterwards, you will receive an email with all of your workspaces.
 2. Username
 3. Password
 
@@ -73,7 +73,7 @@ This endpoint can also be used to ensure you are authenticated.
 
 You will need:
 
-1. Your subdomain -> Refer to [Get Subdomain](https://get.tidalmg.com/workspaces) & type in your email in the prompt bar. Afterwards, You will receive an email with all of your workspaces.
+1. Your subdomain -> Refer to [Get Subdomain](https://get.tidalmg.com/workspaces) & type in your email in the prompt bar. Afterwards, you will receive an email with all of your workspaces.
 2. Your access token -> Refer: [api/v1/authenticate](#getaccess)
 
 ```
@@ -101,7 +101,7 @@ Refresh your access token and generate a new one.
 
 You will need:
 
-1. Your subdomain -> Refer to [Get Subdomain](https://get.tidalmg.com/workspaces) & type in your email in the prompt bar. Afterwards, You will receive an email with all of your workspaces.
+1. Your subdomain -> Refer to [Get Subdomain](https://get.tidalmg.com/workspaces) & type in your email in the prompt bar. Afterwards, you will receive an email with all of your workspaces.
 2. Your access token -> Refer: [api/v1/authenticate](#getaccess)
 3. Your refresh token -> Refer: [api/v1/authenticate](#getaccess)
 

--- a/pages/api/authentication.md
+++ b/pages/api/authentication.md
@@ -23,7 +23,7 @@ A request to authenticate into the Tidal Migrations API looks like this:
 
 You will need:
 
-1. Subdomain -> Refer to [Get Subdomain](https://app.tidalmg.com/?login) & type in your email in the prompt bar.
+1. Your subdomain -> Refer to [Get Subdomain](https://get.tidalmg.com/workspaces) & type in your email in the prompt bar. Afterwards, You will receive an email with all of your workspaces.
 2. Username
 3. Password
 
@@ -73,7 +73,7 @@ This endpoint can also be used to ensure you are authenticated.
 
 You will need:
 
-1. Subdomain -> Refer to [Get Subdomain](https://app.tidalmg.com/?login) & type in your email in the prompt bar.
+1. Your subdomain -> Refer to [Get Subdomain](https://get.tidalmg.com/workspaces) & type in your email in the prompt bar. Afterwards, You will receive an email with all of your workspaces.
 2. Your access token -> Refer: [api/v1/authenticate](#getaccess)
 
 ```
@@ -101,7 +101,7 @@ Refresh your access token and generate a new one.
 
 You will need:
 
-1. Subdomain -> Refer to [Get Subdomain](https://app.tidalmg.com/?login) & type in your email in the prompt bar.
+1. Your subdomain -> Refer to [Get Subdomain](https://get.tidalmg.com/workspaces) & type in your email in the prompt bar. Afterwards, You will receive an email with all of your workspaces.
 2. Your access token -> Refer: [api/v1/authenticate](#getaccess)
 3. Your refresh token -> Refer: [api/v1/authenticate](#getaccess)
 

--- a/pages/api/get_several.md
+++ b/pages/api/get_several.md
@@ -203,7 +203,7 @@ Returns the selected move group and its applications, database instances, and se
 
 You will need:
 
-1. Your subdomain -> Refer: [Get Subdomain](https://get.tidalmg.com/?login) & type in your email in the prompt bar.
+1. Your subdomain -> Refer: [Get Subdomain](https://get.tidalmg.com/?login) & type in your email in the prompt bar. Afterwards, you will receive an email with all of your workspaces.
 2. Your access token -> Refer: [Authentication Guide](index.html).
 3. Your Move Group ID -> Refer to the [above request](#getallmg) to get your move group id.
 

--- a/pages/api/get_several.md
+++ b/pages/api/get_several.md
@@ -25,7 +25,7 @@ Returns a collection of all the move groups and its applications, database insta
 
 You will need:
 
-1. Your subdomain -> Refer: [Get Subdomain](https://app.tidalmg.com/?login) & type in your email in the prompt bar.
+1. Your Subdomain -> Refer to [Get Subdomain](https://get.tidalmg.com/workspaces) & type in your email in the prompt bar. Afterwards, you will receive an email with all of your workspaces.
 2. Your access token -> Refer: [Authentication Guide](index.html)
 
 ```
@@ -203,7 +203,7 @@ Returns the selected move group and its applications, database instances, and se
 
 You will need:
 
-1. Your subdomain -> Refer: [Get Subdomain](https://app.tidalmg.com/?login) & type in your email in the prompt bar.
+1. Your subdomain -> Refer: [Get Subdomain](https://get.tidalmg.com/?login) & type in your email in the prompt bar.
 2. Your access token -> Refer: [Authentication Guide](index.html).
 3. Your Move Group ID -> Refer to the [above request](#getallmg) to get your move group id.
 

--- a/pages/api/get_several.md
+++ b/pages/api/get_several.md
@@ -203,7 +203,7 @@ Returns the selected move group and its applications, database instances, and se
 
 You will need:
 
-1. Your subdomain -> Refer: [Get Subdomain](https://get.tidalmg.com/?login) & type in your email in the prompt bar. Afterwards, you will receive an email with all of your workspaces.
+1. Your subdomain -> Refer: [Get Subdomain](https://get.tidalmg.com/workspaces) & type in your email in the prompt bar. Afterwards, you will receive an email with all of your workspaces.
 2. Your access token -> Refer: [Authentication Guide](index.html).
 3. Your Move Group ID -> Refer to the [above request](#getallmg) to get your move group id.
 

--- a/pages/api/getting_started.md
+++ b/pages/api/getting_started.md
@@ -38,4 +38,4 @@ Two tools that we would recommend are either cURL or Postman.
 
 You can access all of the API documents via https://[your_subdomain].tidalmg.com/docs/
 Replace start of the address above with your Tidal Migrations subdomain.
-For additional help on getting your subdomain, refer to [Get Subdomain](https://app.tidalmg.com/?login) & type in your email in the prompt bar.
+For additional help on getting your subdomain, refer to [Get Subdomain](https://get.tidalmg.com/workspaces) & type in your email in the prompt bar.

--- a/pages/api/getting_started.md
+++ b/pages/api/getting_started.md
@@ -38,4 +38,4 @@ Two tools that we would recommend are either cURL or Postman.
 
 You can access all of the API documents via https://[your_subdomain].tidalmg.com/docs/
 Replace start of the address above with your Tidal Migrations subdomain.
-For additional help on getting your subdomain, refer to [Get Subdomain](https://get.tidalmg.com/workspaces) & type in your email in the prompt bar.
+For additional help on getting your subdomain, refer to [Get Subdomain](https://get.tidalmg.com/workspaces) & type in your email in the prompt bar. Afterwards, you will receive an email with all of your workspaces.

--- a/pages/api/importing_applications.md
+++ b/pages/api/importing_applications.md
@@ -24,7 +24,7 @@ A request to import an application into the Tidal Migrations API looks like this
 
 ### You will need:
 
-1. Your subdomain -> Refer to [Get Subdomain](https://app.tidalmg.com/?login) & type in your email in the prompt bar.
+1. Your subdomain -> Refer to [Get Subdomain](https://get.tidalmg.com/workspaces) & type in your email in the prompt bar. Afterwards, You will receive an email with all of your workspaces.
 2. Your authentication access token -> Refer to [Authentication Guide](index.html)
 3. Your Application Data -> *A JSON object of your applications. The object should be a list with each element in the list being an application object.*
 

--- a/pages/api/importing_applications.md
+++ b/pages/api/importing_applications.md
@@ -24,7 +24,7 @@ A request to import an application into the Tidal Migrations API looks like this
 
 ### You will need:
 
-1. Your subdomain -> Refer to [Get Subdomain](https://get.tidalmg.com/workspaces) & type in your email in the prompt bar. Afterwards, You will receive an email with all of your workspaces.
+1. Your subdomain -> Refer to [Get Subdomain](https://get.tidalmg.com/workspaces) & type in your email in the prompt bar. Afterwards, you will receive an email with all of your workspaces.
 2. Your authentication access token -> Refer to [Authentication Guide](index.html)
 3. Your Application Data -> *A JSON object of your applications. The object should be a list with each element in the list being an application object.*
 

--- a/pages/api/importing_servers.md
+++ b/pages/api/importing_servers.md
@@ -30,7 +30,7 @@ A request to import *one* server into the Tidal Migrations API looks like this:
 
 You will need:
 
-1. Your subdomain -> Refer to [Get Subdomain](https://app.tidalmg.com/?login) & type in your email in the prompt bar.
+1. Your subdomain -> Refer to [Get Subdomain](https://get.tidalmg.com/workspaces) & type in your email in the prompt bar. Afterwards, You will receive an email with all of your workspaces.
 2. Your authentication access token -> Refer to [Authentication Guide](index.html)
 3. Your Server Data -> *A JSON object of your servers. The object should be a list with each element in the list being a server object.*
 
@@ -86,7 +86,7 @@ A request to import *multiple* servers into the Tidal Migrations API looks like 
 
 You will need:
 
-1. Your subdomain -> Refer to [Get Subdomain](https://app.tidalmg.com/?login) & type in your email in the prompt bar.
+1. Your subdomain -> Refer to [Get Subdomain](https://get.tidalmg.com/workspaces) & type in your email in the prompt bar. Afterwards, You will receive an email with all of your workspaces.
 2. Your authentication access token -> Refer to [Authentication Guide](index.html)
 3. Your Server Data -> *A JSON object of your servers. The object should be a list with each element in the list being a server object.*
 

--- a/pages/api/importing_servers.md
+++ b/pages/api/importing_servers.md
@@ -30,7 +30,7 @@ A request to import *one* server into the Tidal Migrations API looks like this:
 
 You will need:
 
-1. Your subdomain -> Refer to [Get Subdomain](https://get.tidalmg.com/workspaces) & type in your email in the prompt bar. Afterwards, You will receive an email with all of your workspaces.
+1. Your subdomain -> Refer to [Get Subdomain](https://get.tidalmg.com/workspaces) & type in your email in the prompt bar. Afterwards, you will receive an email with all of your workspaces.
 2. Your authentication access token -> Refer to [Authentication Guide](index.html)
 3. Your Server Data -> *A JSON object of your servers. The object should be a list with each element in the list being a server object.*
 
@@ -86,7 +86,7 @@ A request to import *multiple* servers into the Tidal Migrations API looks like 
 
 You will need:
 
-1. Your subdomain -> Refer to [Get Subdomain](https://get.tidalmg.com/workspaces) & type in your email in the prompt bar. Afterwards, You will receive an email with all of your workspaces.
+1. Your subdomain -> Refer to [Get Subdomain](https://get.tidalmg.com/workspaces) & type in your email in the prompt bar. Afterwards, you will receive an email with all of your workspaces.
 2. Your authentication access token -> Refer to [Authentication Guide](index.html)
 3. Your Server Data -> *A JSON object of your servers. The object should be a list with each element in the list being a server object.*
 


### PR DESCRIPTION
Update from old login/client system to new workspaces

We need this to be able to host the signup app on get.tidalmg.com only.