### PR TITLE
Updated servicenow guide with databases

### DIFF
--- a/pages/user guides/integrating_with_servicenow.md
+++ b/pages/user guides/integrating_with_servicenow.md
@@ -7,12 +7,12 @@ sidebar: main_sidebar
 permalink: integrate-with-servicenow.html
 ---
 
-Prepare your ServiceNow instance by importing our custom-made update set, then creating an OAuth endpoint. Once this is set up, you can send your existing apps and servers to your ServiceNow instance. All relationships between these entities will be preserved, and can be viewed in ServiceNow.  
+Prepare your ServiceNow instance by importing our custom-made update set, then creating an OAuth endpoint. Once this is set up, you can send your existing apps, servers and databases to your ServiceNow instance. All relationships between these entities will be preserved, and can be viewed in ServiceNow.  
 
 
 
 {% include note.html content="This feature is currently available for beta users only.
-We currently support syncing of applications and servers with up to 3000 of each record." %}
+We currently support syncing of applications, servers and databases with up to 3000 of each record." %}
 
 
 ## Preparing your ServiceNow Instance
@@ -45,15 +45,11 @@ You can find the Tidal Migrations ServiceNow update set [here](https://github.co
 
 {% include image.html file="update-set-step5.png" %}
 
-- It is possible that this process will fail with errors. If this happens, close the loading window and scroll to the 'Update Set Preview Problem' table. In this table, where possible, click 'accept remote update' to resolve each issue. If this option is not available, click 'skip remote update' to resolve the issue. After the issues are resolved, you can proceed as normal.
-
-{% include image.html file="update-set-issues.png" %}
-
 - Once this has completed, close the loading bar and click 'Commit Update Set' in the top right corner of the window. This will show another loading bar as your update set is committed. This process should take around ten minutes.
 
 {% include image.html file="update-set-step6.png" %}
 
-- Once the update set has been committed, you can type 'Tidal Migrations' in the filter navigation bar, and see where your servers, apps and (in future) databases will be saved.
+- Once the update set has been committed, you can type 'Tidal Migrations' in the filter navigation bar, and see where your servers, apps and databases will be saved.
 
 {% include image.html file="update-set-step7.png" %}
 
@@ -104,11 +100,11 @@ In order for your Tidal Migrations workspace to communicate with your ServiceNow
 
   Note: The username and password here are for your ServiceNow instance. If you don't know them, go to the ServiceNow developer page and find 'Manage instance password'. 
 
-- Hit 'Create Connection' to connect this workspace to your ServiceNow instance. This action will automatically push all of your current apps and servers over to your ServiceNow instance.
+- Hit 'Create Connection' to connect this workspace to your ServiceNow instance. This action will automatically push all of your current apps, servers and databases over to your ServiceNow instance.
 
   {% include image.html file="integrate-tidal-step1.png" %}
 
-- Return to ServiceNow and find your data under the Tidal Migrations -> 'Applications' and 'Servers' tables.
+- Return to ServiceNow and find your data under the Tidal Migrations -> 'Applications', 'Servers' and 'Databases' tables.
 
   {% include image.html file="integrate-tidal-step2.png" %}
 


### PR DESCRIPTION
Now that the servicenow update set has been updated, we can re-add database support to the feature. This PR updates the guides accordingly, and also removes references to update set import errors, which have been resolved. 