### PR TITLE
Update download location for preconfigured VM images

### DIFF
--- a/pages/user guides/tidal-vms.md
+++ b/pages/user guides/tidal-vms.md
@@ -28,4 +28,4 @@ The _server install_ images do not have a graphical user interface and are suita
 
 ### Download link
 
-- [tidal-ubuntu-18.04-server-amd64.ova](https://preconfigured-vms.s3.ca-central-1.amazonaws.com/tidal-ubuntu-18.04-server-amd64.ova)
+- [tidal-ubuntu-18.04-server-amd64.ova](https://d2ny8m13pxxvfx.cloudfront.net/tidal-ubuntu-18.04-server-amd64.ova)


### PR DESCRIPTION
Updated the download link for the preconfigured Ubuntu VM served from this page. It's now located in a new S3 bucket behind a cloudfront distribution. 