### PR TITLE
Update new OVA related information

### DIFF
--- a/pages/user guides/tidal-vms.md
+++ b/pages/user guides/tidal-vms.md
@@ -1,30 +1,30 @@
 ---
 title: Pre-Configured Virtual Machines
 keywords: vm, virtual, machine, image, ova, ovf, aws, ami, tidal, tools
-last_updated: November, 2021
+last_updated: January, 2022
 summary: "Virtual machines pre-configured with Tidal software"
 sidebar: main_sidebar
 permalink: pre-configured-vms.html
 ---
 
-To help you get your Tidal Migrations discovery phase up and running, we've created a series of pre-configured virtual machines with common operating systems. These VMs have the latest Tidal software and dependencies installed for you, so you can focus on getting things done.
+To help you get your Tidal Migrations discovery phase up and running, we've created a pre-configured virtual machines image. These VMs have the latest Tidal softwares and dependencies installed for you, so you can focus on getting things done.
 
 ## Ubuntu 18.04
 
-The Ubuntu-18.04-server-amd64 image comes with [Tidal tools](https://tidalmigrations.com/tidal-tools/) and [Machine Stats](https://pypi.org/project/machine-stats/) installed. To get started, download the Virtual Machine image from the link given below. You can import this OVA file into your VirtualBox or VMware Workstation. Use the following credentials for SSH.
+The Ubuntu-18.04-server-amd64 image comes with the latest version of [Tidal Tools](https://tidalmigrations.com/tidal-tools/) and [Machine Stats](https://pypi.org/project/machine-stats/) installed. To get started, download the Virtual Machine image from the link given below. You can import this OVA file into your VirtualBox or VMware Workstation. Use the following credentials to login.
 
 ```
-Username: vagrant
-Password: vagrant
+Username: ubuntu
+Password: tidal
 ```
 
-The _server install_ images do not have a graphical user interface and are suitable for AMD64 or EM64T architecture-based systems. To know more about this image type, visit [Ubuntu 18.04.6 LTS (Bionic Beaver)](https://cdimage.ubuntu.com/ubuntu/releases/18.04.6/release/).
+The Virtual Machine image is built with the latest ubuntu-bionic-18.04-amd64-server image available from Ubuntu for AWS. You can locate the source AMI from [Ubuntu Cloud Image Finder](https://cloud-images.ubuntu.com/locator/).
 
 ### Minimum System Requirements
 
 - Memory: 2 GB
-- Processors: 2
-- Free Storage Space: 30 GB
+- Processors: 1
+- Free Storage Space: 8 GB
 
 ### Download link
 

--- a/pages/user guides/tidal-vms.md
+++ b/pages/user guides/tidal-vms.md
@@ -7,7 +7,7 @@ sidebar: main_sidebar
 permalink: pre-configured-vms.html
 ---
 
-To help you get your Tidal Migrations discovery phase up and running, we've created a pre-configured virtual machines image. These VMs have the latest Tidal softwares and dependencies installed for you, so you can focus on getting things done.
+To help you get your Tidal Migrations discovery phase up and running, we've created a pre-configured virtual machine images. These VMs have the latest Tidal softwares and dependencies installed for you, so you can focus on getting things done.
 
 ## Ubuntu 18.04
 

--- a/pages/user guides/tidal-vms.md
+++ b/pages/user guides/tidal-vms.md
@@ -7,7 +7,7 @@ sidebar: main_sidebar
 permalink: pre-configured-vms.html
 ---
 
-To help you get your Tidal Migrations discovery phase up and running, we've created a pre-configured virtual machine images. These VMs have the latest Tidal softwares and dependencies installed for you, so you can focus on getting things done.
+To help you get your Tidal Migrations discovery phase up and running, we've created a pre-configured virtual machine image. This VM has the latest Tidal software and dependencies installed for you, so you can focus on getting things done.
 
 ## Ubuntu 18.04
 

--- a/pages/user guides/tidal-vms.md
+++ b/pages/user guides/tidal-vms.md
@@ -2,12 +2,12 @@
 title: Pre-Configured Virtual Machines
 keywords: vm, virtual, machine, image, ova, ovf, aws, ami, tidal, tools
 last_updated: January, 2022
-summary: "Virtual machines pre-configured with Tidal software"
+summary: "Virtual machines pre-configured with Tidal Migrations software"
 sidebar: main_sidebar
 permalink: pre-configured-vms.html
 ---
 
-To help you get your Tidal Migrations discovery phase up and running, we've created a pre-configured virtual machine image. This VM has the latest Tidal software and dependencies installed for you, so you can focus on getting things done.
+To help you get your Tidal Migrations discovery phase up and running, we've created a pre-configured virtual machine image. This VM has the latest Tidal Migrations software and dependencies installed for you, so you can focus on getting things done.
 
 ## Ubuntu 18.04
 


### PR DESCRIPTION
A pass over the existing guides for Ubuntu 18.04 VM image since we have changed our approach from VMware as a builder to exporting OVA from the AWS EC2. This is also done to make the image available for public use.