### PR TITLE
Added MS4U limitations

### DIFF
--- a/pages/tidal tools/machine_stats.md
+++ b/pages/tidal tools/machine_stats.md
@@ -183,13 +183,17 @@ __< 250 Subjects__
 
 When scanning fewer than 250 subject machines, we recommend a controller machine with the following minimum specifications:
 - vCPUs: 2
+- Clock Speed: 3.1 GHz
 - RAM (GB): 2
+- RAM Type: DDR4
 
 __250 - 800 Subjects__
 
 When scanning up to 800 subject machines, we recommend a controller machine with the following minimum specifications:
 - vCPUs: 4
+- Clock Speed: 2.5 GHz
 - RAM (GB): 16
+- RAM Type: DDR4
 
 __> 800 Subjects__
 

--- a/pages/tidal tools/machine_stats.md
+++ b/pages/tidal tools/machine_stats.md
@@ -175,6 +175,26 @@ The `*/5` means that cron will execute this script every 5 minutes. You can cust
 
 Your results should appear in the existing `<path-to-results-directory>` that you specified in the `run-machine-stats.sh` script. Each result filename will contain a timestamp of when the invocation occurred.
 
+### Recommended Specs
+
+Under our testing conditions, we have found that Machine Stats for Unix requires the following specifications of the controller machine. This is intended as a general guide only, as all testing was performed on virtual machines in AWS. Your mileage may vary scanning on-premise servers on your network.
+
+__< 250 Subjects__
+
+When scanning fewer than 250 subject machines, we recommend a controller machine with the following minimum specifications:
+- vCPUs: 2
+- RAM (GB): 2
+
+__250 - 800 Subjects__
+
+When scanning up to 800 subject machines, we recommend a controller machine with the following minimum specifications:
+- vCPUs: 4
+- RAM (GB): 16
+
+__> 800 Subjects__
+
+We cannot guarantee the success of Machine Stats for Unix when scanning more than 800 subject machines. If you need to operate at this scale, we recommend sharding your inventory into smaller groups and using multiple controller machines.
+
 ### Technical Documentation
 
 For more details on configuration and usage, please check Machine Stats for

--- a/pages/user guides/tidal-vms.md
+++ b/pages/user guides/tidal-vms.md
@@ -23,6 +23,9 @@ The _server install_ images do not have a graphical user interface and are suita
 
 ### Minimum System Requirements
 
+{% include note.html content="If you're planning on using this VM to capture data with Machine Stats for Unix, you may want to consider using an instance with more powerful specifications. For more information, see the [recommended specs](https://guides.tidalmg.com/machine_stats.html#recommended-specs) for Machine Stats for Unix." %}
+
+Recommended Minimum Specs:
 - Memory: 2 GB
 - vCPU: 2
 - Free Storage Space: 8 GB

--- a/pages/user guides/tidal-vms.md
+++ b/pages/user guides/tidal-vms.md
@@ -23,7 +23,7 @@ The _server install_ images do not have a graphical user interface and are suita
 
 ### Minimum System Requirements
 
-{% include note.html content="If you're planning on using this VM to capture data with Machine Stats for Unix, you may want to consider using an instance with more powerful specifications. For more information, see the [recommended specs](https://guides.tidalmg.com/machine_stats.html#recommended-specs) for Machine Stats for Unix." %}
+{% include note.html content="If you're planning on using this VM to capture data with Machine Stats for Unix, you may want to consider using a machine with more powerful specifications. For more information, see the [recommended specs](https://guides.tidalmg.com/machine_stats.html#recommended-specs) for Machine Stats for Unix." %}
 
 Recommended Minimum Specs:
 - Memory: 2 GB


### PR DESCRIPTION
Added a recommended specs section to the guide for Machine Stats for Unix. This breaks down our specs into three bands, as suggested [here](https://tidalmg.slack.com/archives/C01LZV12W90/p1649434189150119).

Also added a note to the Ubuntu preconfigured VM linking to the recommended specs.