### PR TITLE
Fix navigation for vm guide

### DIFF
--- a/_data/sidebars/main_sidebar.yml
+++ b/_data/sidebars/main_sidebar.yml
@@ -60,9 +60,9 @@ entries:
           - title: Windows DNS Zonefile Export
             output: web
             url: windows-zone-export.html
-          - title: Pre-Configured Virtual Machine
+          - title: Tidal Tools Virtual Machine Image
             output: web
-            url: pre-configured-vms.html
+            url: tidal-discovery-vm.html
 
       - title: Assess
         output: web


### PR DESCRIPTION
Currently the link in the main navigation returns a page not found error! This fixes that