### PR TITLE
Fix a Tidal tools title and add machine stats keywords

### DIFF
--- a/pages/tidal tools/google.md
+++ b/pages/tidal tools/google.md
@@ -1,12 +1,13 @@
 ---
-title: Getting Started with Tidal Tools on Google Cloud Platform</span>
-keywords: Google, marketplace, tidal tools
+title: Getting Started with Tidal Tools on Google Cloud Platform
+keywords: Google, marketplace, tidal tools, gcp
 last_updated: November 2, 2020
 summary: Configure and use Tidal Tools from the Google Cloud Marketplace
 sidebar: main_sidebar
 permalink: tidal-tools-gcp.html
 folder: tidaltools
 ---
+
 Using Tidal Tools you can easily discover and assess your applications and their infrastructure. You can get started and rapidly capture what technologies are in use, on which networks and with what DNS configuration.
 
 {% include note.html content="This page describes how to configure and use Tidal Tools from the Google Cloud Marketplace, it can also be [installed on many other systems](tidal-tools.html)." %}

--- a/pages/tidal tools/machine_stats.md
+++ b/pages/tidal tools/machine_stats.md
@@ -1,7 +1,7 @@
 ---
 title: Gather Machine Stats
-keywords:
-last_updated: December, 2021
+keywords: machine, stats, cron, job, windows, unix
+last_updated: April, 2022
 summary: "Gather machine stats from remote environments"
 sidebar: main_sidebar
 permalink: machine_stats.html


### PR DESCRIPTION
A couple of minor improvements:
- Add keywords to the Machine Stats page
- Fix a Tidal Tools title
   ![image](https://user-images.githubusercontent.com/30822450/184652537-8a72e43a-06bb-42ad-b9e7-2aeff4a9a135.png)
 