### PR TITLE
Removed out-of-context reference to CPU utilization gathering

### DIFF
--- a/pages/tidal tools/machine_stats.md
+++ b/pages/tidal tools/machine_stats.md
@@ -284,7 +284,7 @@ This approach is useful when you want to take a snapshot of your infrastructure 
 
 #### Run Machine Stats on a Cron Job
 
-By leveraging cron, you can run Machines Stats on a schedule to gather data over a period of time. This is useful if you want to gather utilization data, for example recording the CPU utilization of your machines over a set period.
+By leveraging cron, you can run Machines Stats on a schedule to gather data over a period of time.
 
 Since we're not piping the result to Tidal Migrations Platform, and are instead saving the result files locally, this approach can be used on an offline server.
 


### PR DESCRIPTION
CPU utilization gathering is not currently intended for public use. The guide includes an off-hand reference to it as a use case. This PR removes that to eliminate confusion. 