### PR TITLE
chore: add ruby to list of supported code analysis languages

### DIFF
--- a/pages/assess/code_analysis_overview.md
+++ b/pages/assess/code_analysis_overview.md
@@ -20,6 +20,7 @@ Analyzes an application's source code for various patterns that are useful in as
 |                              C# |      ✅     |         ✅        |           ✅          |           ✅          |           ✅          |
 |                            Java |      ✅     |         ✅        |           ✅          |           ✅          |           ✅          |
 |                      JavaScript |      ✅     |         ✅        |           ✅          |           ✅          |           ✅          |
+|                            Ruby |      ✅     |         ✅        |           ✅          |           ✅          |           ✅          |
 |                          Python |      ✅     |         ➖        |           ✅          |           ✅          |           ✅          |
 |                           COBOL |      ✅     |         ➖        |           ✅          |           ➖          |           ➖          |
 |                             PHP |      ✅     |         ➖        |           ✅          |           ➖          |           ➖          |


### PR DESCRIPTION
Update code analysis docs to reflect our new Ruby language support across Tidal Tools and Tidal Accelerator